### PR TITLE
Fix failing test with build123d==0.6.0 by moving from Edge.intersections to Edge.find_intersection_points

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ name: Python tests
 on:
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "gridfinity_build123d"
 version = "0.1.0"
 description = "Build123d library for gridfinity objects"
 dependencies = [
-    "build123d==0.5.0",
+    "build123d==0.6.0",
     "bd_warehouse@git+https://github.com/gumyr/bd_warehouse@7e68dfecc03c7ab64cc9c41d8b1313f060137bb8",
 ]
 requires-python = ">=3.8"

--- a/src/gridfinity_build123d/bin.py
+++ b/src/gridfinity_build123d/bin.py
@@ -142,10 +142,10 @@ class StackingLip:
                 edge = (
                     path.edges()
                     .sort_by(Axis.X)
-                    .filter_by(lambda edge: edge.intersections(Axis.X))
+                    .filter_by(lambda edge: edge.find_intersection_points(Axis.X))
                     .sort_by(Axis.X)[-1]
                 )
-                point = edge.intersections(Axis.X)[0]
+                point = edge.find_intersection_points(Axis.X)[0]
 
                 with Locations((point.X, point.Z)), Locations(
                     (-profile.sketch.bounding_box().max.X, 0),


### PR DESCRIPTION
Also added a workflow dispatch for manually triggering the tests since they weren't triggering on my fork correctly