### PR TITLE
test_unit_features.py -> loosen test tolerance to 6 places instead of 7

### DIFF
--- a/tests/test_unit_features.py
+++ b/tests/test_unit_features.py
@@ -255,7 +255,7 @@ class GridfinityRefinedThreadedScrewHoleTest(testutils.UtilTestCase):
             bbox.size,
             5,
         )
-        self.assertAlmostEqual(670.6352585350687, part.volume)
+        self.assertAlmostEqual(670.6352585350687, part.volume, 6)
 
 
 class GridfinityRefinedMagnetHolePressfitTest(testutils.UtilTestCase):


### PR DESCRIPTION
Fix failing test so build123d==0.8.0 can proceed