### PR TITLE
allow newer versions of build123d and ocp_vscode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "gridfinity_build123d"
 version = "0.1.0"
 description = "Build123d library for gridfinity objects"
 dependencies = [
-    "build123d==0.9.0",
+    "build123d>=0.9.0",
     "bd_warehouse@git+https://github.com/gumyr/bd_warehouse@48c507baac94231e2eb2c4032848719660f964dc",
 ]
 requires-python = ">=3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 mypy==1.18.2
 coverage==7.10.7
 vulture==2.14
-ocp_vscode==2.9.0
+ocp_vscode>=2.9.0
 parameterized==0.9.0
 ruff==0.14.3
 pytest-markdown-docs==0.9.0


### PR DESCRIPTION
* I am using "uv" to create a python environment for using build123d and the ocp_vscode viewer, but when I wanted to add gridfinity_build123d it required me to downgrade to older versions of python build123d and ocp_vscode
* I changed the requirements from exact versions to minimum versions: in pyproject.toml: old: "build123d==0.9.0" new: "build123d>=0.9.0" in requirements.txt: old: ocp_vscode==2.9.0 new: ocp_vscode>=2.9.0
* after the change, I could "uv add" this package, and my tests all ran successfully
* my test environment is using: python 3.12.3 build123d 0.10.0 ocp-vscode 3.0.1